### PR TITLE
integrate jib

### DIFF
--- a/src/java/README.md
+++ b/src/java/README.md
@@ -1,0 +1,17 @@
+# Java Dapr modules
+
+There are 2 Dapr modules based on the Java SDK.
+
+## Build
+
+These maven projects uses [Jib maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) to build repeatable
+images.
+
+To build using Jib, go to the maven project example: `techtalks-consumer/`
+
+Followed by.
+
+``` shell
+mvn compile jib:build -D-Djib.to.image=myregistry/myimage:latest
+```
+

--- a/src/java/techtalks-consumer/pom.xml
+++ b/src/java/techtalks-consumer/pom.xml
@@ -44,13 +44,26 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>3.1.0</version>
+			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<from>
+						<!-- Use the sha to make sure it is reproducible this is based on eclipse-temurin:19-jre-alpine-->
+						<image>eclipse-temurin@sha256:dde223014bd6917ea00d9eb370add424dc5dfcbcfcb8e8efac15a050563d312e</image>
+					</from>
+					<to>
+						<image>balchu/dapr-techtalks-consumer</image>
+					</to>
+					<container>
+						<mainClass>ccom.nileshgule.techtalksconsumer.TechTalksConsumerApplication</mainClass>
+					</container>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/java/techtalks-producer/pom.xml
+++ b/src/java/techtalks-producer/pom.xml
@@ -60,8 +60,21 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<from>
+						<!-- Use the sha to make sure it is reproducible this is based on eclipse-temurin:19-jre-alpine-->
+						<image>eclipse-temurin@sha256:dde223014bd6917ea00d9eb370add424dc5dfcbcfcb8e8efac15a050563d312e</image>
+					</from>
+					<to>
+						<image>balchu/dapr-techtalks-producer</image>
+					</to>
+					<container>
+						<mainClass>ccom.nileshgule.techtalksproducer.TechTalksProducerApplication</mainClass>
+					</container>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR integrates the `jib-maven` to the java projects.

Jib is not going to be executed by `docker-compose`, it is more integrated with maven.